### PR TITLE
PR-003 make arg completion more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+playground/

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -29,12 +29,12 @@ __{{.ProgramName}}_get_completion_results() {
     lastChar=${lastParam:$((${#lastParam}-1)):1}
     __{{.ProgramName}}_debug "lastParam ${lastParam}, lastChar ${lastChar}"
 
-    # if [[ -z ${cur} && ${lastChar} != = ]]; then
-    #     # If the last parameter is complete (there is a space following it)
-    #     # We add an extra empty parameter so we can indicate this to the go method.
-    #     __{{.ProgramName}}_debug "Adding extra empty parameter"
-    #     requestComp="${requestComp} ''"
-    # fi
+    if [[ -z ${cur} && ${lastChar} != = ]]; then
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go method.
+        __{{.ProgramName}}_debug "Adding extra empty parameter"
+        requestComp="${requestComp} ''"
+    fi
 
     # When completing a flag with an = (e.g., {{.ProgramName}} -n=<TAB>)
     # bash focuses on the part after the =, so we need to remove

--- a/cli.go
+++ b/cli.go
@@ -598,6 +598,7 @@ func (p *App) parseArgs(v any, opts ...ParseOpt) (fs *flag.FlagSet, err error) {
 	// For completion, we parse the command arguments,
 	// then transmit the executing to `continueCompletion`.
 	if p.isCompletion {
+		p.completionCtx.parsedArgs = v
 		p.checkLastArgForCompletion()
 		p.parseArgsForCompletion()
 		p.continueCompletion()

--- a/cli.go
+++ b/cli.go
@@ -598,11 +598,7 @@ func (p *App) parseArgs(v any, opts ...ParseOpt) (fs *flag.FlagSet, err error) {
 	// For completion, we parse the command arguments,
 	// then transmit the executing to `continueCompletion`.
 	if p.isCompletion {
-		p.completionCtx.parsedArgs = v
-		p.checkLastArgForCompletion()
-		p.parseArgsForCompletion()
-		p.continueCompletion()
-		p.completionCtx.postFunc()
+		p.continueCompletion(v)
 		return
 	}
 

--- a/comp_arguments.go
+++ b/comp_arguments.go
@@ -25,10 +25,10 @@ type ArgCompletionContext interface {
 	ArgPrefix() string
 }
 
-func newArgCompletionContext(app *App) ArgCompletionContext {
+func (p *App) newArgCompletionContext() ArgCompletionContext {
 	return &compContextImpl{
 		Context: context.Background(),
-		app:     app,
+		app:     p,
 	}
 }
 

--- a/comp_arguments.go
+++ b/comp_arguments.go
@@ -2,63 +2,8 @@ package mcli
 
 import (
 	"context"
-)
-
-/*
-Arg completion tag syntax (WIP):
-
-	`comp:"nofile"`
-	`comp:"enums=a,b,c,d;"`
-	`comp:"fn=funcName"`
-	`comp:"listExt=json,yaml,toml"`
-	`comp:"listFiles"`  // and listDirs, listDirsAndFiles, etc.
-
-*/
-
-// ShellCompDirective is a bit map representing the different behaviors the shell
-// can be instructed to have once completions have been provided.
-type ShellCompDirective int
-
-const (
-	// ShellCompDirectiveError indicates an error occurred and completions should be ignored.
-	ShellCompDirectiveError ShellCompDirective = 1 << iota
-
-	// ShellCompDirectiveNoSpace indicates that the shell should not add a space
-	// after the completion even if there is a single completion provided.
-	ShellCompDirectiveNoSpace
-
-	// ShellCompDirectiveNoFileComp indicates that the shell should not provide
-	// file completion even when no completion is provided.
-	ShellCompDirectiveNoFileComp
-
-	// ShellCompDirectiveFilterFileExt indicates that the provided completions
-	// should be used as file extension filters.
-	// For flags, using Command.MarkFlagFilename() and Command.MarkPersistentFlagFilename()
-	// is a shortcut to using this directive explicitly.  The BashCompFilenameExt
-	// annotation can also be used to obtain the same behavior for flags.
-	ShellCompDirectiveFilterFileExt
-
-	// ShellCompDirectiveFilterDirs indicates that only directory names should
-	// be provided in file completion.  To request directory names within another
-	// directory, the returned completions should specify the directory within
-	// which to search.  The BashCompSubdirsInDir annotation can be used to
-	// obtain the same behavior but only for flags.
-	ShellCompDirectiveFilterDirs
-
-	// ShellCompDirectiveKeepOrder indicates that the shell should preserve the order
-	// in which the completions are provided
-	ShellCompDirectiveKeepOrder
-
-	// ===========================================================================
-
-	// All directives using iota should be above this one.
-	// For internal use.
-	shellCompDirectiveMaxValue
-
-	// ShellCompDirectiveDefault indicates to let the shell perform its default
-	// behavior after completions have been provided.
-	// This one must be last to avoid messing up the iota count.
-	ShellCompDirectiveDefault ShellCompDirective = 0
+	"flag"
+	"strings"
 )
 
 type CompletionItem struct {
@@ -74,53 +19,61 @@ type ArgCompletionFunc func(ctx ArgCompletionContext) []CompletionItem
 type ArgCompletionContext interface {
 	context.Context
 
-	Args() []string
+	GlobalFlags() any
+	CommandArgs() any
+	FlagSet() *flag.FlagSet
+	ArgPrefix() string
+}
+
+func newArgCompletionContext(app *App) ArgCompletionContext {
+	return &compContextImpl{
+		Context: context.Background(),
+		app:     app,
+	}
 }
 
 type compContextImpl struct {
-	*Context
-	app  *App
-	args []string
+	context.Context
+	app *App
 }
 
-func (c compContextImpl) Args() []string {
-	return c.args
+func (c *compContextImpl) GlobalFlags() any {
+	return c.app.globalFlags
 }
 
-// func (c compContextImpl) App() []string {
-// 	return c.app
-// }
+func (c *compContextImpl) CommandArgs() any {
+	return c.app.completionCtx.parsedArgs
+}
 
-// WithArgCompFuncs for struct holding completion functions for use with flags args completion
+func (c *compContextImpl) FlagSet() *flag.FlagSet {
+	return c.app.getFlagSet()
+}
+
+func (c *compContextImpl) ArgPrefix() string {
+	return c.app.completionCtx.prefixWord
+}
+
+// WithArgCompFuncs specifies completion functions to complete flag values
+// or positional arguments.
+// Key of funcMap should be a flag name in form "-flag" or a positional arg name "arg1".
 func WithArgCompFuncs(funcMap map[string]ArgCompletionFunc) ParseOpt {
+	copyMap := make(map[string]ArgCompletionFunc)
+	for name, x := range funcMap {
+		name = normalizeCompFlagName(name)
+		copyMap[name] = x
+	}
 	return ParseOpt{f: func(options *parseOptions) {
-		options.argCompFuncs = funcMap
+		options.argCompFuncs = copyMap
 	}}
 }
 
-// WithCommandCompFuncs for holding completion functions for use with args completions
-func WithCommandCompFunc(function ArgCompletionFunc) CmdOpt {
-	return CmdOpt{f: func(options *cmdOptions) {
-		options.argCompFunc = function
-	}}
+func normalizeCompFlagName(s string) string {
+	if strings.HasPrefix(s, "-") {
+		s = "-" + strings.TrimLeft(s, "-")
+	}
+	return strings.TrimSpace(s)
 }
 
-// func compByFunc(funcName string) ArgCompletionFunc {
-// 	return func(ctx ArgCompletionContext) ([][]string, ShellCompDirective) {
-// 		panic("not implemented")
-// 	}
-// }
-//
-// func compNofile(ctx ArgCompletionContext) ([][]string, ShellCompDirective) {
-// 	return nil, ShellCompDirectiveNoFileComp
-// }
-
-// func compEnums(values []string) ArgCompletionFunc {
-// 	return func(ctx ArgCompletionContext) ([][]string, ShellCompDirective) {
-// 		return values, ShellCompDirectiveDefault
-// 	}
-// }
-
-// func compListFilesExt(extList [][]string) ArgCompletionFunc {
-// 	panic("not implemented")
-// }
+func cleanFlagName(s string) string {
+	return strings.TrimLeft(s, "-")
+}

--- a/comp_arguments_test.go
+++ b/comp_arguments_test.go
@@ -1,0 +1,187 @@
+package mcli
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArgCompletionContext(t *testing.T) {
+	resetDefaultApp()
+	addTestCompletionCommands()
+
+	type globalFlags struct {
+		G1 bool   `cli:"-g, --global-1"`
+		G2 string `cli:"-G, --global-2"`
+	}
+
+	type testArgs struct {
+		A  []string `cli:"-a, --a-flag, description a flag"`
+		A1 bool     `cli:"-1, --1-flag"`
+		S1 bool     `cli:"-s1, --s1-flag"`
+		S2 bool     `cli:"-s2, --s2-flag"`
+		V1 string   `cli:"value1"`
+		V2 int64    `cli:"value2"`
+	}
+
+	argCompFuncs := map[string]ArgCompletionFunc{
+		"-a": func(ctx ArgCompletionContext) []CompletionItem {
+			args := ctx.CommandArgs().(*testArgs)
+			if args.S1 {
+				return nil
+			}
+			return []CompletionItem{
+				{"abc", "abc description"},
+				{"def", "def description"},
+			}
+		},
+		"value1": func(ctx ArgCompletionContext) []CompletionItem {
+			gf := ctx.GlobalFlags().(*globalFlags)
+			if gf.G1 {
+				return []CompletionItem{
+					{"Tom", "Tom who"},
+					{"John", "John Smith"},
+				}
+			}
+			if gf.G2 == "hello" {
+				return []CompletionItem{
+					{"world", "Hello world!"},
+					{"there", "Hello there!"},
+				}
+			}
+			return []CompletionItem{
+				{"dummy-value-1", ""},
+			}
+		},
+		"value2": func(ctx ArgCompletionContext) []CompletionItem {
+			fs := ctx.FlagSet()
+			prefix := ctx.ArgPrefix()
+			compItems := []CompletionItem{
+				{"abc-1", "abc 1 description"},
+				{"abc-2", "abc 2 description"},
+				{"def-3", "def 3 description"},
+				{"def-4", "def 4 description"},
+			}
+			if fs.Lookup("s2").Value.(flag.Getter).Get() == true {
+				var result []CompletionItem
+				for _, x := range compItems {
+					if strings.HasPrefix(x.Value, prefix) {
+						result = append(result, x)
+					}
+				}
+				return result
+			}
+			return compItems
+		},
+	}
+	cmdFunc := func(ctx *Context, args *testArgs) {
+		// pass
+	}
+	testCmd := NewCommand(cmdFunc, WithArgCompFuncs(argCompFuncs))
+
+	defaultApp.SetGlobalFlags(&globalFlags{})
+	Add("group1 cmdv", testCmd, "A group1 cmdv description")
+
+	var buf bytes.Buffer
+	defaultApp.completionCtx.out = &buf
+
+	reset := func() {
+		buf.Reset()
+		defaultApp.resetParsingContext()
+		defaultApp.resetCompletionCtx()
+		defaultApp.SetGlobalFlags(&globalFlags{})
+	}
+
+	t.Run("suggest flags", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "-", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Contains(t, got1, "-a:description a flag\n")
+		assert.Contains(t, got1, "-1\n")
+		assert.Contains(t, got1, "--s1:--s1-flag\n")
+		assert.Contains(t, got1, "--s2:--s2-flag\n")
+	})
+
+	t.Run("suggest flag value / s1 true", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "-s1", "-a", "", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Equal(t, got1, "")
+	})
+
+	t.Run("suggest flag value / s1 false", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "-a", "", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Contains(t, got1, "abc:abc description\n")
+		assert.Contains(t, got1, "def:def description\n")
+	})
+
+	t.Run("suggest value1 / g1 true", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "-g", "", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Contains(t, got1, "Tom:Tom who\n")
+		assert.Contains(t, got1, "John:John Smith\n")
+	})
+
+	t.Run("suggest value1 / g2 hello", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "-G", "hello", "", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Contains(t, got1, "world:Hello world!\n")
+		assert.Contains(t, got1, "there:Hello there!\n")
+	})
+
+	t.Run("suggest value1 / default", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "-g=0", "-G", "there", "", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Contains(t, got1, "dummy-value-1\n")
+	})
+
+	t.Run("suggest value2 / s2 true", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "-s2=1", "value1 value", "", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Contains(t, got1, "abc-1:abc 1 description\n")
+		assert.Contains(t, got1, "abc-2:abc 2 description\n")
+		assert.Contains(t, got1, "def-3:def 3 description\n")
+		assert.Contains(t, got1, "def-4:def 4 description\n")
+
+		reset()
+		Run("group1", "cmdv", "-s2", "value1 value", "abc", completionFlag, "zsh")
+		got2 := buf.String()
+		assert.Contains(t, got2, "abc-1:abc 1 description\n")
+		assert.Contains(t, got2, "abc-2:abc 2 description\n")
+		assert.NotContains(t, got2, "def-3")
+		assert.NotContains(t, got2, "def-4")
+
+		reset()
+		Run("group1", "cmdv", "-s2", "value1 value", "abd", completionFlag, "zsh")
+		got3 := buf.String()
+		assert.Equal(t, got3, "")
+	})
+
+	t.Run("suggest value2 / s2 false", func(t *testing.T) {
+		reset()
+		Run("group1", "cmdv", "value1 value", "", completionFlag, "zsh")
+		got1 := buf.String()
+		assert.Contains(t, got1, "abc-1:abc 1 description\n")
+		assert.Contains(t, got1, "abc-2:abc 2 description\n")
+		assert.Contains(t, got1, "def-3:def 3 description\n")
+		assert.Contains(t, got1, "def-4:def 4 description\n")
+
+		reset()
+		Run("group1", "cmdv", "value1 value", "abc", completionFlag, "zsh")
+		got2 := buf.String()
+		assert.Contains(t, got2, "abc-1:abc 1 description\n")
+		assert.Contains(t, got2, "abc-2:abc 2 description\n")
+		assert.Contains(t, got2, "def-3:def 3 description\n")
+		assert.Contains(t, got2, "def-4:def 4 description\n")
+	})
+
+}

--- a/completion.go
+++ b/completion.go
@@ -4,20 +4,29 @@ import (
 	"embed"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"text/template"
 )
 
 const completionFlag = "--mcli-generate-completion"
 
-type completionMethod struct {
-	isFlag       bool
-	flagName     string
-	isFlagValue  bool
-	isCommand    bool
-	foundCommand *Command
-	userArgs     []string
-	isCommandArg bool
+type completionCtx struct {
+	out      io.Writer // help in testing to inspect completion output
+	postFunc func()    // help in testing to not exit the program
+	shell    string
+	userArgs []string
+	cmd      *cmdTree
+
+	lastArg           string
+	hasFlag           bool
+	wantFlagValue     bool
+	flagName          string
+	wantPositionalArg bool
+	prefixWord        string
+
+	cmdArgs    *[]string
+	parsedArgs any
 }
 
 func getAllowedShells() []string {
@@ -40,88 +49,211 @@ func hasCompletionFlag(args []string) (bool, []string, string) {
 	return true, args, shell
 }
 
-func completedCommand(args []string, c commands) *Command {
-	cReversed := reverse(c)
-	line := strings.Join(args, " ")
-	for _, item := range cReversed {
-		if strings.HasPrefix(line, item.Name) {
-			return item
+func (p *App) setupCompletionCtx(userArgs []string, completionShell string) {
+	p.isCompletion = true
+	if p.completionCtx.out == nil {
+		p.completionCtx.out = os.Stdout
+	}
+	if p.completionCtx.postFunc == nil {
+		p.completionCtx.postFunc = func() {
+			os.Exit(0)
 		}
 	}
-	return nil
+	p.completionCtx.shell = completionShell
+
+	// Parse completion ctx information.
+	for _, arg := range userArgs {
+		if strings.HasPrefix(arg, "-") {
+			p.completionCtx.hasFlag = true
+			break
+		}
+	}
+	if n := len(userArgs); n > 0 {
+		p.completionCtx.lastArg = userArgs[n-1]
+		userArgs = userArgs[:n-1]
+	}
+	p.completionCtx.userArgs = userArgs
+	p.completionCtx.cmdArgs = &userArgs
 }
 
-func detectCompletionMethod(args []string, c commands) completionMethod {
-	var lastArg string
-	if len(args) > 0 {
-		lastArg = args[len(args)-1]
-	}
+func (p *App) doAutoCompletion(userArgs []string) {
+	ctx := p.getParsingContext()
+	tree := p.parseCompletionCmdTree()
 
-	if lastArg == "-" {
-		return completionMethod{
-			isFlag:   true,
-			flagName: lastArg,
-			userArgs: args[:len(args)-1],
+	cmdNames := userArgs
+	hasFlag := false
+	for i, x := range userArgs {
+		if strings.HasPrefix(x, "-") {
+			hasFlag = true
+			cmdNames = userArgs[:i]
+			break
 		}
 	}
 
-	if strings.HasPrefix(lastArg, "-") {
-		return completionMethod{
-			isFlagValue: true,
-			flagName:    lastArg,
-			userArgs:    args,
-		}
+	tree, leftArgs := tree.findCommand(cmdNames)
+	if tree == nil {
+		return
 	}
 
-	catched := completedCommand(args, c)
-	if catched != nil {
-		if catched.isGroup {
-			return completionMethod{
-				isCommand:    true,
-				userArgs:     args,
-				foundCommand: catched,
+	p.completionCtx.cmd = tree
+	ctx.cmd = tree.Cmd
+
+	isGroupCmd := tree.Cmd == nil || tree.Cmd.isGroup
+	isLeafCmd := len(tree.SubCmds) == 0
+	shouldParseArgs := hasFlag || !isGroupCmd || isLeafCmd
+	if !shouldParseArgs {
+		// Suggest sub-commands.
+		cmdWord := ""
+		if len(leftArgs) > 0 {
+			cmdWord = leftArgs[0]
+		}
+		tree.suggestSubCommands(p, cmdWord)
+		return
+	}
+
+	tree.suggestFlagAndArgs(p)
+}
+
+func (p *App) checkLastArgForCompletion() {
+	pCtx := p.getParsingContext()
+	compCtx := &p.completionCtx
+	if compCtx.lastArg != "" {
+		if strings.HasPrefix(compCtx.lastArg, "-") {
+			if valIdx := strings.Index(compCtx.lastArg, "="); valIdx >= 0 {
+				// The last incomplete word is a flag, and it wants a value.
+				compCtx.wantFlagValue = true
+				compCtx.flagName = compCtx.lastArg[:valIdx]
+				compCtx.prefixWord = compCtx.lastArg[valIdx+1:]
+			} else {
+				// The last word is a flag, it could be either complete or incomplete,
+				// try to suggest a flag.
+				compCtx.prefixWord = strings.TrimLeft(compCtx.lastArg, "-")
 			}
 		} else {
-			return completionMethod{
-				userArgs:     args,
-				isCommandArg: true,
-				foundCommand: catched,
+			// The last incomplete word is not a flag,
+			// check the second last word.
+			var secondLastWord string
+			if len(compCtx.userArgs) > 0 {
+				secondLastWord = compCtx.userArgs[len(compCtx.userArgs)-1]
+			}
+			if secondLastWord != "" {
+				// The second last word is a flag.
+				if strings.HasPrefix(secondLastWord, "-") {
+					if strings.Contains(secondLastWord, "=") {
+						// The second last word is a flag and has its value,
+						// the user is requesting a positional arg.
+						compCtx.wantPositionalArg = true
+						compCtx.prefixWord = compCtx.lastArg
+					} else {
+						flagName := strings.TrimLeft(secondLastWord, "-")
+						for _, f := range pCtx.flags {
+							if f.name == flagName || f.short == flagName {
+								if f.isBoolean() {
+									// Boolean flags do not accept values,
+									// the user is requesting a positional arg.
+									compCtx.wantPositionalArg = true
+									compCtx.prefixWord = compCtx.lastArg
+								} else {
+									// A non-boolean flag wants a value from command line.
+									compCtx.wantFlagValue = true
+									compCtx.flagName = normalizeCompFlagName(flagName)
+									compCtx.prefixWord = compCtx.lastArg
+									// The second last arg is the flag name,
+									// don't pass this incomplete flag to parsing the FlagSet.
+									*compCtx.cmdArgs = compCtx.userArgs[:len(compCtx.userArgs)-1]
+								}
+								break
+							}
+						}
+					}
+				} else if compCtx.cmd.isLeaf() {
+					compCtx.wantPositionalArg = true
+					compCtx.prefixWord = compCtx.lastArg
+				} else {
+					// The user may be requesting a command or a positional arg.
+					compCtx.prefixWord = compCtx.lastArg
+				}
+			}
+		}
+	} else {
+		// The last word is complete, check if it's a flag,
+		// and if it's a boolean flag, a boolean flag does not take a value.
+		var lastWord string
+		if len(compCtx.userArgs) > 0 {
+			lastWord = compCtx.userArgs[len(compCtx.userArgs)-1]
+		}
+		if lastWord != "" {
+			if strings.HasPrefix(lastWord, "-") {
+				if strings.Contains(lastWord, "=") {
+					// The last word is a flag and has its value,
+					// the user is most probably requesting a positional arg.
+					compCtx.wantPositionalArg = true
+				} else {
+					flagName := strings.TrimLeft(lastWord, "-")
+					for _, f := range pCtx.flags {
+						if f.name == flagName || f.short == flagName {
+							if f.isBoolean() {
+								// Boolean flags do not accept values,
+								// the user is requesting a positional arg.
+								compCtx.wantPositionalArg = true
+							} else {
+								// A non-boolean flag wants a value from command line.
+								compCtx.wantFlagValue = true
+								compCtx.flagName = normalizeCompFlagName(flagName)
+								// The last word is the flag name,
+								// don't pass this incomplete flag to parsing the FlagSet.
+								*compCtx.cmdArgs = compCtx.userArgs[:len(compCtx.userArgs)-1]
+							}
+							break
+						}
+					}
+				}
+			} else if compCtx.cmd.isLeaf() {
+				compCtx.wantPositionalArg = true
+			} else {
+				// The user may be requesting a command or a positional arg.
+				// pass
 			}
 		}
 	}
-
-	// User has provided other flags, this completion request is for another flag.
-	return completionMethod{
-		userArgs: args,
-	}
 }
 
-func (p *App) doAutoCompletion(args []string) {
-	tree := p.parseCompletionInfo()
-	cm := detectCompletionMethod(args, p.cmds)
-	p.completionCtx.completionMethod = cm
-	// fmt.Printf("%+v\n", cm)
-
-	if cm.isCommand {
-		tree.suggestCommands(p, cm)
-	} else if cm.isCommandArg {
-		tree.suggestCommandArgs(p, cm)
-	} else if cm.isFlag {
-		tree.suggestFlags(p, cm)
-	} else if cm.isFlagValue {
-		checkCommandArg := tree.suggestFlags(p, cm)
-		if checkCommandArg {
-			tree.suggestCommandArgs(p, cm)
-		}
-	} else {
-		checkFlag := tree.suggestCommands(p, cm)
-		if checkFlag {
-			tree.suggestFlags(p, cm)
-		}
+func (p *App) parseArgsForCompletion() {
+	ctx := p.getParsingContext()
+	fs := ctx.getFlagSet()
+	cmdArgs := p.getCmdArgs()
+	flagsReordered := ctx.args != nil
+	if !flagsReordered {
+		cmdArgs = ctx.reorderFlags(cmdArgs)
 	}
+
+	var err error
+
+	// If the command does not receive arguments, but there are still
+	// arguments before flags, it is absolutely an invalid command.
+	if !checkNonflagsLength(ctx.nonflags, ctx.ambiguousArgs) {
+		err = newInvalidCmdError(ctx)
+		ctx.failError(err)
+		return
+	}
+
+	// Expand the posix-style single-token-multiple-values flags.
+	if p.Options.AllowPosixSTMO {
+		cmdArgs = expandSTMOFlags(ctx.flagMap, cmdArgs)
+	}
+
+	if err = fs.Parse(cmdArgs); err != nil {
+		return
+	}
+	nonflagArgs, err := ctx.parseNonflags()
+	if err != nil {
+		return
+	}
+	tidyFlags(fs, ctx.flags, nonflagArgs)
+	return
 }
 
-func (p *App) parseCompletionInfo() *cmdTree {
+func (p *App) parseCompletionCmdTree() *cmdTree {
 	p.cmds.sort()
 	rootCmd := newCmdTree("", nil)
 	for _, cmd := range p.cmds {
@@ -143,6 +275,10 @@ func newCmdTree(name string, cmd *Command) *cmdTree {
 		Cmd:     cmd,
 		SubTree: make(map[string]*cmdTree),
 	}
+}
+
+func (t *cmdTree) isLeaf() bool {
+	return len(t.SubCmds) == 0
 }
 
 func (t *cmdTree) add(cmd *Command) {
@@ -168,41 +304,30 @@ func (t *cmdTree) add(cmd *Command) {
 	}
 }
 
-func (t *cmdTree) suggestCommands(app *App, cm completionMethod) (checkFlag bool) {
-	userArgs := cm.userArgs
+func (t *cmdTree) findCommand(cmdNames []string) (tree *cmdTree, leftArgs []string) {
 	cur := t
 	i := 0
-	for i < len(userArgs)-1 {
-		name := userArgs[i]
-		cur = cur.SubTree[name]
-		if cur == nil || (cur.Cmd != nil && cur.Cmd.isCompletion) {
-			return false
+	for i < len(cmdNames) {
+		name := cmdNames[i]
+		sub := cur.SubTree[name]
+		if sub == nil {
+			return cur, cmdNames[i:]
 		}
+		if sub.Cmd != nil && sub.Cmd.isCompletion {
+			return nil, nil
+		}
+		cur = sub
 		i++
 	}
-	gotCmd := true
-	lastWord := ""
-	if len(userArgs) > 0 {
-		lastWord = userArgs[len(userArgs)-1]
-		if n, ok := cur.SubTree[lastWord]; ok {
-			cur = n
-		} else {
-			gotCmd = false
-		}
-	}
-	// If the command is a leaf command, check flag for completion.
-	if gotCmd && len(cur.SubCmds) == 0 {
-		return true
-	}
+	return cur, nil
+}
 
-	matchFunc := func(n *cmdTree) bool { return true }
-	if !gotCmd {
-		matchFunc = func(n *cmdTree) bool {
-			return strings.HasPrefix(n.Name, lastWord)
-		}
+func (t *cmdTree) suggestSubCommands(app *App, cmdWord string) {
+	matchFunc := func(n *cmdTree) bool {
+		return strings.HasPrefix(n.Name, cmdWord)
 	}
 	result := make([]string, 0, 16)
-	for _, sub := range cur.SubCmds {
+	for _, sub := range t.SubCmds {
 		if sub.Cmd == nil && len(sub.SubCmds) == 0 {
 			continue
 		}
@@ -219,53 +344,43 @@ func (t *cmdTree) suggestCommands(app *App, cm completionMethod) (checkFlag bool
 		suggestion := formatCompletion(app, sub.Name, desc)
 		result = append(result, suggestion)
 	}
-
 	printLines(app.completionCtx.out, result)
-	return false
 }
 
-func (t *cmdTree) suggestCommandArgs(app *App, cm completionMethod) {
-	result := []string{}
-	if cm.foundCommand != nil {
-		cmdOpts := newCmdOptions(cm.foundCommand.cmdOpts...)
-		app.argsCtx = &compContextImpl{
-			app:  app,
-			args: cm.userArgs,
-		}
-		f := cmdOpts.argCompFunc
-		if f != nil {
-			res := f(app.argsCtx)
-			for _, item := range res {
-				result = append(result, formatCompletion(app, item.Value, item.Description))
-			}
-		}
-		printLines(app.completionCtx.out, result)
-	}
-}
-
-func (t *cmdTree) suggestFlags(app *App, cm completionMethod) bool {
-	cmd := completedCommand(cm.userArgs, app.cmds)
+func (t *cmdTree) suggestFlagAndArgs(app *App) {
+	cmd := t.Cmd
 	if cmd == nil || cmd.isGroup || cmd.isCompletion {
-		return false
+		return
 	}
 
-	// Check that flag completion is enabled for the command.
+	// check that flag completion is enabled for the command.
 	cmdOpts := newCmdOptions(cmd.cmdOpts...)
 	isCmdFlagEnabled := app.EnableFlagCompletionForAllCommands || cmdOpts.enableFlagCompletion
 	if !isCmdFlagEnabled {
-		return true
+		return
 	}
 
 	// Parse flags for the command,
 	// then transmit the executing to the parsing function.
-	app.completionCtx.flagName = cm.flagName
 	cmd.f()
-	return true
+	return
 }
 
-func (p *App) continueFlagCompletion() {
+func (p *App) continueCompletion() {
+	compCtx := p.completionCtx
+	if compCtx.wantPositionalArg {
+		p.continuePositionalArgCompletion()
+		return
+	}
+	if compCtx.wantFlagValue {
+		p.continueFlagValueCompletion()
+		return
+	}
+
+	// Else try to complete flags.
+
 	getUsage := func(f *_flag) string {
-		if p.completionCtx.shell == "powershell" {
+		if compCtx.shell == "powershell" {
 			return ""
 		}
 		_, usage := f.getUsage(false)
@@ -278,8 +393,8 @@ func (p *App) continueFlagCompletion() {
 	}
 
 	seenFlags := make(map[string]bool)
-	leadingArgs := subSlice(p.completionCtx.userArgs, 0, -1)
-	for _, arg := range leadingArgs {
+	cmdArgs := p.getCmdArgs()
+	for _, arg := range cmdArgs {
 		if !strings.HasPrefix(arg, "-") {
 			continue
 		}
@@ -296,67 +411,89 @@ func (p *App) continueFlagCompletion() {
 		return seenFlags[f.short] || seenFlags[f.name]
 	}
 
-	flagName := p.completionCtx.flagName
-	flags := p.completionCtx.flags
-	funcs := p.completionCtx.argCompFuncs
-	cm := p.completionCtx.completionMethod
-
+	pCtx := p.getParsingContext()
+	prefixWord := compCtx.prefixWord
 	result := make([]string, 0, 16)
-	var completionFunc ArgCompletionFunc
-
-	_, cleanFlagName := countFlagPrefixHyphen(flagName)
-
-	if cm.isFlagValue {
-		for _, flag := range flags {
-			if flag.short != "" && flag.short != "-" && strings.HasPrefix(flag.short, cleanFlagName) && (flag.isCompositeType() || !isSeenFlag(flag)) {
-				if f, ok := funcs["-"+flag.short]; ok {
-					completionFunc = f
-				}
-			}
-			if flag.name != "" && flag.name != "--" && strings.HasPrefix(flag.name, cleanFlagName) && (flag.isCompositeType() || !isSeenFlag(flag)) {
-				if f, ok := funcs["--"+flag.name]; ok {
-					completionFunc = f
-				}
-			}
-		}
-
-		if completionFunc != nil {
-			res := completionFunc(p.argsCtx)
-			result = []string{}
-			for _, item := range res {
-				result = append(result, formatCompletion(p, item.Value, item.Description))
-			}
-		}
-	}
-
-	if completionFunc == nil || cm.isFlag {
-		for _, flag := range flags {
+	for _, flag := range pCtx.flags {
+		if flag.short != "" && strings.HasPrefix(flag.short, prefixWord) && (flag.isCompositeType() || !isSeenFlag(flag)) {
 			usage := getUsage(flag)
-			if flag.short != "" && flag.short != "-" && strings.HasPrefix(flag.short, cleanFlagName) && (flag.isCompositeType() || !isSeenFlag(flag)) {
-				suggestion := formatCompletion(p, "-"+flag.short, usage)
-				result = append(result, suggestion)
-			}
+			suggestion := formatCompletion(p, "-"+flag.short, usage)
+			result = append(result, suggestion)
+		}
 
-			if flag.name != "" && flag.name != "--" && strings.HasPrefix(flag.name, cleanFlagName) && (flag.isCompositeType() || !isSeenFlag(flag)) {
-				suggestion := formatCompletion(p, "--"+flag.name, usage)
-				result = append(result, suggestion)
-			}
+		if flag.name != "" && strings.HasPrefix(flag.name, prefixWord) && (flag.isCompositeType() || !isSeenFlag(flag)) {
+			usage := getUsage(flag)
+			suggestion := formatCompletion(p, "--"+flag.name, usage)
+			result = append(result, suggestion)
 		}
 	}
-
 	printLines(p.completionCtx.out, result)
 }
 
-func countFlagPrefixHyphen(flagName string) (int, string) {
-	n := 0
-	for _, c := range flagName {
-		if c == '-' {
-			n++
-			continue
+func (p *App) continueFlagValueCompletion() {
+	pCtx := p.getParsingContext()
+	compCtx := p.completionCtx
+	flagName := cleanFlagName(compCtx.flagName)
+
+	var f *_flag
+	for _, x := range pCtx.flags {
+		if x.name == flagName || x.short == flagName {
+			f = x
+			break
 		}
-		break
 	}
-	return n, flagName[n:]
+	if f == nil {
+		return
+	}
+	compFunc := pCtx.opts.argCompFuncs["-"+f.name]
+	if compFunc == nil {
+		compFunc = pCtx.opts.argCompFuncs["-"+f.short]
+		if compFunc == nil {
+			return
+		}
+	}
+	acc := newArgCompletionContext(p)
+	compItems := compFunc(acc)
+	printCompletionItems(p, compItems)
+}
+
+func (p *App) continuePositionalArgCompletion() {
+	pCtx := p.getParsingContext()
+	fs := pCtx.getFlagSet()
+
+	if len(pCtx.nonflags) == 0 {
+		return
+	}
+
+	var nf = pCtx.nonflags[0]
+	var i, j int
+	for i < fs.NArg() && j < len(pCtx.nonflags) {
+		nf = pCtx.nonflags[j]
+		if !nf.isCompositeType() {
+			j++
+		}
+		i++
+	}
+	if nf == nil {
+		return
+	}
+
+	compFunc := pCtx.opts.argCompFuncs[nf.name]
+	if compFunc == nil {
+		return
+	}
+	acc := newArgCompletionContext(p)
+	compItems := compFunc(acc)
+	printCompletionItems(p, compItems)
+}
+
+func printCompletionItems(app *App, items []CompletionItem) {
+	result := make([]string, 0, len(items))
+	for _, x := range items {
+		s := formatCompletion(app, x.Value, x.Description)
+		result = append(result, s)
+	}
+	printLines(app.completionCtx.out, result)
 }
 
 func printLines(w io.Writer, lines []string) {

--- a/completion.go
+++ b/completion.go
@@ -467,7 +467,7 @@ func (p *App) continuePositionalArgCompletion() {
 
 	var nf = pCtx.nonflags[0]
 	var i, j int
-	for i < fs.NArg() && j < len(pCtx.nonflags) {
+	for i <= fs.NArg() && j < len(pCtx.nonflags) {
 		nf = pCtx.nonflags[j]
 		if !nf.isCompositeType() {
 			j++

--- a/completion_test.go
+++ b/completion_test.go
@@ -515,7 +515,7 @@ func TestFormatCompletion(t *testing.T) {
 			defaultApp.completionCtx.out = &buf
 			defaultApp.completionCtx.shell = tt.shell
 
-			got := formatCompletion(defaultApp, "option", "some option description")
+			got := defaultApp.formatCompletion("option", "some option description")
 			assert.Equal(t, got, "option"+tt.connector+"some option description")
 		})
 	}
@@ -528,7 +528,7 @@ func TestFormatCompletion(t *testing.T) {
 			defaultApp.completionCtx.out = &buf
 			defaultApp.completionCtx.shell = tt.shell
 
-			got := formatCompletion(defaultApp, "option", "")
+			got := defaultApp.formatCompletion("option", "")
 			assert.Equal(t, got, "option")
 		})
 	}

--- a/slice_utils.go
+++ b/slice_utils.go
@@ -1,5 +1,7 @@
 package mcli
 
+import "strings"
+
 func clip[S ~[]E, E any](s S) S {
 	return s[:len(s):len(s)]
 }
@@ -46,4 +48,15 @@ func reverse[T any](original []T) (reversed []T) {
 	}
 
 	return
+}
+
+func removeCommandName(args []string, cmdName string) []string {
+	cmdWords := strings.Fields(cmdName)
+	i := 0
+	for ; i < len(cmdWords) && i < len(args); i++ {
+		if cmdWords[i] != args[i] {
+			break
+		}
+	}
+	return args[i:]
 }

--- a/slice_utils_test.go
+++ b/slice_utils_test.go
@@ -58,3 +58,26 @@ func TestSubSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveCommandName(t *testing.T) {
+	t.Run("match command", func(t *testing.T) {
+		cmdName := "group1 cmd1 sub1"
+		args := []string{"group1", "cmd1", "sub1", "-a", "-b", "12345"}
+		got := removeCommandName(args, cmdName)
+		assert.Equal(t, []string{"-a", "-b", "12345"}, got)
+	})
+
+	t.Run("partial match", func(t *testing.T) {
+		cmdName := "group1 cmd1 sub2"
+		args := []string{"group1", "cmd1", "sub1", "-a", "-b", "12345"}
+		got := removeCommandName(args, cmdName)
+		assert.Equal(t, []string{"sub1", "-a", "-b", "12345"}, got)
+	})
+
+	t.Run("not match", func(t *testing.T) {
+		cmdName := "group2 cmd1"
+		args := []string{"group1", "cmd1", "sub1", "-a", "-b", "12345"}
+		got := removeCommandName(args, cmdName)
+		assert.Equal(t, []string{"group1", "cmd1", "sub1", "-a", "-b", "12345"}, got)
+	})
+}


### PR DESCRIPTION
Hi, sorry for the late review.
I made some changes to the code, which let the completion funciton be more flexable.

There are some works left, hope you can help.
1. review the code
2. shell scripts should be changed to pass an extra empty string "" to the program when the last word is complete, e.g. "program cmd1 -a [TAB][TAB]" (note the space after "-a"), `bash_autocomplete` has already been changed.
3. ~more tests to cover the various use-case (nice to have, not must)~